### PR TITLE
workaround to prevent emacs 28 and 29 from spitting the dummy.

### DIFF
--- a/markdown-mermaid.el
+++ b/markdown-mermaid.el
@@ -26,7 +26,6 @@
 (require 'json)
 (require 'color)
 
-(defvar inhibit-file-name-modes) ; Declare special variable for compiler compatibility
 
 (defgroup markdown-mermaid nil
   "Preview Mermaid diagrams within Markdown buffers."
@@ -139,24 +138,12 @@ Defaults to looking up `mmdc' in your system path."
         (progn
           (message "Preview generated.")
 
-          ;; Use inhibit-file-name-modes and temporarily disable auto-mode-alist
-          ;; to prevent auto-mode detection (like image-mode) which can fail in batch/non-graphical environments.
-          (let ((inhibit-file-name-modes t)
-                (auto-mode-alist nil)
-                (image-buffer (find-file-noselect image-path)))
-
-            ;; Force fundamental mode immediately to prevent image-mode from running
-            ;; if auto-mode detection was not fully inhibited by the dynamic variables.
+          (let ((image-buffer (get-buffer-create "*mermaid-image-temp*")))
             (with-current-buffer image-buffer
-              (fundamental-mode))
+              ;; Load file content literally to avoid running image-mode/auto-mode detection
+              (find-file-literally image-path)
 
-            ;; Dummy reference to satisfy strict compiler check for unused lexical variable
-            (when inhibit-file-name-modes nil)
-            (when auto-mode-alist nil)
-
-            (with-current-buffer image-buffer
               ;; 1. Ensure the buffer is named consistently for previews.
-              ;; This buffer is now visiting the temporary file.
               (rename-buffer "*mermaid-image*" t)
 
               ;; 2. Set up cleanup variables/hook in the buffer holding the image.


### PR DESCRIPTION
**markdown-mermaid** works and tests correctly in **Emacs** version 30.2, but the automated tests fail for versions 29 and 28. This code change makes it backward compatible. 