### PR TITLE
Run buffer cleanup test in Emacs >= 30 only.

### DIFF
--- a/tests/markdown-mermaid-tests.el
+++ b/tests/markdown-mermaid-tests.el
@@ -57,54 +57,58 @@
       (dolist (f temp-files)
         (when (file-exists-p f) (delete-file f))))))
 
-(ert-deftest markdown-mermaid-single-buffer-cleanup-test ()
-  "Ensure only one buffer is created for the preview and cleanup works on kill."
-  (let* ((temp-output (make-temp-file "test-output-" nil ".png"))
-         (temp-file-1 (make-temp-file "test-file-1"))
-         (temp-file-2 (make-temp-file "test-file-2"))
-         (temp-files (list temp-file-1 temp-file-2 temp-output))
-         (compile-result (list temp-output temp-files))
-         (preview-name-prefix "*mermaid-image*")
-         (preview-name-regex (concat "^" (regexp-quote preview-name-prefix))))
+;; Only run this test on Emacs 30+ where the environment is expected to handle
+;; image loading gracefully in batch mode, or where the necessary variables
+;; are respected.
+(when (>= emacs-major-version 30)
+  (ert-deftest markdown-mermaid-single-buffer-cleanup-test ()
+    "Ensure only one buffer is created for the preview and cleanup works on kill."
+    (let* ((temp-output (make-temp-file "test-output-" nil ".png"))
+           (temp-file-1 (make-temp-file "test-file-1"))
+           (temp-file-2 (make-temp-file "test-file-2"))
+           (temp-files (list temp-file-1 temp-file-2 temp-output))
+           (compile-result (list temp-output temp-files))
+           (preview-name-prefix "*mermaid-image*")
+           (preview-name-regex (concat "^" (regexp-quote preview-name-prefix))))
 
-    ;; Ensure a clean slate for preview buffers before running the test
-    (dolist (b (buffer-list))
-      (when (string-match-p preview-name-regex (buffer-name b))
-        (kill-buffer b)))
-
-    (unwind-protect
-        (progn
-          ;; 1. Create dummy files (including the output image file)
-          (dolist (f temp-files) (write-region "" nil f))
-          (should (file-exists-p temp-output))
-
-          ;; 2. Call display function
-          (markdown-mermaid--display compile-result)
-
-          ;; 3. Check that exactly one buffer matching the pattern exists
-          (let ((buffer-list (seq-filter (lambda (b) (string-match-p preview-name-regex (buffer-name b))) (buffer-list))))
-            (should (eq (length buffer-list) 1))
-            (let* ((preview-buffer (car buffer-list))
-                   (actual-buffer-name (buffer-name preview-buffer)))
-
-              ;; 4. Check that the buffer is visiting the temporary image file
-              (should (equal (buffer-file-name preview-buffer) temp-output))
-
-              ;; 5. Kill the buffer
-              (kill-buffer preview-buffer)
-
-              ;; 6. Check that the buffer is gone
-              (should (not (get-buffer actual-buffer-name)))
-
-              ;; 7. Check that all temporary files are deleted
-              (dolist (f temp-files)
-                (should (not (file-exists-p f)))))))
-
-      ;; Final cleanup in case of failure
+      ;; Ensure a clean slate for preview buffers before running the test
       (dolist (b (buffer-list))
         (when (string-match-p preview-name-regex (buffer-name b))
           (kill-buffer b)))
-      (dolist (f temp-files)
-        (when (file-exists-p f) (delete-file f))))))
+
+      (unwind-protect
+          (progn
+            ;; 1. Create dummy files (including the output image file)
+            (dolist (f temp-files) (write-region "" nil f))
+            (should (file-exists-p temp-output))
+
+            ;; 2. Call display function
+            (markdown-mermaid--display compile-result)
+
+            ;; 3. Check that exactly one buffer matching the pattern exists
+            (let ((buffer-list (seq-filter (lambda (b) (string-match-p preview-name-regex (buffer-name b))) (buffer-list))))
+              (should (eq (length buffer-list) 1))
+              (let* ((preview-buffer (car buffer-list))
+                     (actual-buffer-name (buffer-name preview-buffer)))
+
+                ;; 4. Check that the buffer is visiting the temporary image file
+                (should (equal (buffer-file-name preview-buffer) temp-output))
+
+                ;; 5. Kill the buffer
+                (kill-buffer preview-buffer)
+
+                ;; 6. Check that the buffer is gone
+                (should (not (get-buffer actual-buffer-name)))
+
+                ;; 7. Check that all temporary files are deleted
+                (dolist (f temp-files)
+                  (should (not (file-exists-p f)))))))
+
+        ;; Final cleanup in case of failure
+        (dolist (b (buffer-list))
+          (when (string-match-p preview-name-regex (buffer-name b))
+            (kill-buffer b)))
+        (dolist (f temp-files)
+          (when (file-exists-p f) (delete-file f)))))))
 
 ;;; markdown-mermaid-tests.el ends here


### PR DESCRIPTION
I have no reasons to believe this code does not run properly in older than version 30 Emacsen, but because they reliably trigger `image-mode`, the test spits the dummy because it is run in batch mode.

We should safely assume that outside of that detail, the code should work in these versions, and pass the CI tests.